### PR TITLE
Fix an issue with escaping curl URL in zsh

### DIFF
--- a/plugin/corona-stats.vim
+++ b/plugin/corona-stats.vim
@@ -10,7 +10,7 @@ function! s:corona_stats() abort
   \]
   call add(l:lines, map(deepcopy(l:keys), 'v:val[1]'))
 
-  let l:contents = system('curl -s https://corona-stats.online?format=json')
+  let l:contents = system('curl -s "https://corona-stats.online?format=json"')
   let l:resp = json_decode(l:contents)
   for l:row in l:resp.data + [l:resp.worldStats]
     call add(l:lines, map(deepcopy(l:keys), 'l:row[v:val[0]]'))


### PR DESCRIPTION
## Bug

```
E474: Unidentified byte: zsh:1: no matches found: https://corona-stats.online?format=json^@
E474: Failed to parse zsh:1: no matches found: https://corona-stats.online?format=json^@
```

## Solution
Just escape the URL string with quotes.